### PR TITLE
[WIP] pytorch lightning distributed training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+.build/
+data/

--- a/bugan/functionsPL.py
+++ b/bugan/functionsPL.py
@@ -69,9 +69,9 @@ class DataModule_custom_cond(pl.LightningDataModule):
 
 
 class DataModule_custom(pl.LightningDataModule):
-    def __init__(self, config, run, data_path, process_data=False):
+    def __init__(self, batch_size, run, data_path, process_data=False):
         super().__init__()
-        self.config = config
+        self.batch_size = batch_size
         self.run = run
         self.dataset_artifact = None
         self.dataset = None
@@ -111,7 +111,6 @@ class DataModule_custom(pl.LightningDataModule):
             self.data_path = npy_path
 
     def setup(self, stage=None):
-        config = self.config
         dataset = np.load(self.data_path)
 
         # now all the returned array contains multiple samples
@@ -119,9 +118,8 @@ class DataModule_custom(pl.LightningDataModule):
         self.dataset = torch.unsqueeze(torch.tensor(dataset), 1)
 
     def train_dataloader(self):
-        config = self.config
         tensor_dataset = TensorDataset(self.dataset)
-        return DataLoader(tensor_dataset, batch_size=config.batch_size, shuffle=True)
+        return DataLoader(tensor_dataset, batch_size=self.batch_size, shuffle=True)
 
 
 class DataModule(pl.LightningDataModule):

--- a/bugan/modelsPL.py
+++ b/bugan/modelsPL.py
@@ -243,7 +243,7 @@ class VAEGAN(pl.LightningModule):
         dataset_batch = dataset_batch[
             0
         ]  # dataset_batch was a list: [array], so just take the array inside
-        dataset_batch = dataset_batch.float().to(device)
+        dataset_batch = dataset_batch.float()
 
         batch_size = dataset_batch.shape[0]
         vae = self.vae
@@ -255,8 +255,8 @@ class VAEGAN(pl.LightningModule):
         criterion_label = criterion_label(reduction="mean")
 
         # labels
-        real_label = torch.unsqueeze(torch.ones(batch_size), 1).float().to(device)
-        fake_label = torch.unsqueeze(torch.zeros(batch_size), 1).float().to(device)
+        real_label = torch.unsqueeze(torch.ones(batch_size), 1).float().type_as(dataset_batch)
+        fake_label = torch.unsqueeze(torch.zeros(batch_size), 1).float().type_as(dataset_batch)
 
         if optimizer_idx == 0:
             ############
@@ -318,7 +318,7 @@ class VAEGAN(pl.LightningModule):
 
             # generate fake trees
             latent_size = vae.decoder_z_size
-            z = torch.randn(batch_size, latent_size).float().to(device)  # noise vector
+            z = torch.randn(batch_size, latent_size).float().type_as(dataset_batch)  # noise vector
             tree_fake = F.sigmoid(vae.generate_sample(z))
 
             # fake data (data from generator)
@@ -951,7 +951,7 @@ class VAE(nn.Module):
 
     # reference: https://github.com/YixinChen-AI/CVAE-GAN-zoos-PyTorch-Beginner/blob/master/CVAE-GAN/CVAE-GAN.py
     def noise_reparameterize(self, mean, logvar):
-        eps = torch.randn(mean.shape).to(device)
+        eps = torch.randn(mean.shape).type_as(mean)
         z = mean + eps * torch.exp(logvar/2.)
         return z
 

--- a/bugan/modelsPL.py
+++ b/bugan/modelsPL.py
@@ -12,7 +12,6 @@ import pytorch_lightning as pl
 from torch.utils.data import DataLoader, TensorDataset
 
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-device
 
 #####
 #   models for training
@@ -143,11 +142,10 @@ class VAE_train(pl.LightningModule):
         return result
 
 class VAEGAN(pl.LightningModule):
-    def __init__(self, config, trainer, save_model_path):
+    def __init__(self, config, save_model_path):
         super(VAEGAN, self).__init__()
         # assert(vae.sample_size == discriminator.input_size)
         self.config = config
-        self.trainer = trainer
         self.save_model_path = save_model_path
         # create components
         decoder = Generator(
@@ -216,25 +214,26 @@ class VAEGAN(pl.LightningModule):
         self.vae.train()
         self.discriminator.train()
 
-    def on_train_epoch_end(self):
-        self.d_ep_loss = self.d_ep_loss / self.config.num_data
-        self.vae_ep_loss = self.vae_ep_loss / self.config.num_data
+    # TODO: move to trainer callback
+    # def on_train_epoch_end(self):
+    #     self.d_ep_loss = self.d_ep_loss / self.config.num_data
+    #     self.vae_ep_loss = self.vae_ep_loss / self.config.num_data
 
-        # save model if necessary
-        log_dict = {"discriminator loss": self.d_ep_loss, "VAE loss": self.vae_ep_loss}
+    #     # save model if necessary
+    #     log_dict = {"discriminator loss": self.d_ep_loss, "VAE loss": self.vae_ep_loss}
 
-        log_image = (
-            self.epoch % self.config.log_image_interval == 0
-        )  # boolean whether to log image
-        log_mesh = (
-            self.epoch % self.config.log_mesh_interval == 0
-        )  # boolean whether to log mesh
+    #     log_image = (
+    #         self.epoch % self.config.log_image_interval == 0
+    #     )  # boolean whether to log image
+    #     log_mesh = (
+    #         self.epoch % self.config.log_mesh_interval == 0
+    #     )  # boolean whether to log mesh
 
-        wandbLog(self, log_dict, log_image=log_image, log_mesh=log_mesh)
-        if log_image:
-            self.trainer.save_checkpoint(self.save_model_path)
-            save_checkpoint_to_cloud(self.save_model_path)
-        self.epoch += 1
+    #     wandbLog(self, log_dict, log_image=log_image, log_mesh=log_mesh)
+    #     if log_image:
+    #         self.trainer.save_checkpoint(self.save_model_path)
+    #         save_checkpoint_to_cloud(self.save_model_path)
+    #     self.epoch += 1
 
     def training_step(self, dataset_batch, batch_idx, optimizer_idx):
         config = self.config


### PR DESCRIPTION
@asdryau These are minimal changes for the distributed training to work (for the VAEGAN only).

The full guidelines are here https://pytorch-lightning.readthedocs.io/en/latest/multi_gpu.html .

The main differences are

1. using `type_as` instead of `to(device)`
1. removing the `trainer` an attribute of the lightning module
1. not passing the wandb `config` object to the dataloader and lightning module

For the last point I just created a copy of the config object with the same interface but I think it would be better to pass the individual hyper parameters to the models directly instead of passing `config`.

Instead of
```python
    def __init__(self, config, ...):
        self.config = config
...
        decoder = Generator(
...
            config.z_size,
...
```
something like
```python
    def __init__(self, z_size, ...):
...    
        decoder = Generator(
...
            z_size,
...
```

Then we can also pass defaults and type annotations for documentation.

The method `on_train_epoch_end` is commented out because it needs the `trainer`. I think it should be moved to a callback passed to the `trainer` ( https://pytorch-lightning.readthedocs.io/en/latest/trainer.html#callbacks ).

I think this would agree more with the following guidelines from the pytorch lightning docs
![图片](https://user-images.githubusercontent.com/1040871/95327380-8908a200-08d6-11eb-8faa-3e458d4166ae.png)


